### PR TITLE
Integrate https://github.com/christiaan/InlineStyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+mosaico-php-backend.iml
+autoload.php
+vendor
+composer.phar

--- a/README.md
+++ b/README.md
@@ -4,13 +4,25 @@ This is a PHP backend for Mosaico
 
 Mosaico can be found at https://github.com/voidlabs/mosaico
 
-First, install and set up Mosaico.  Then install these files on top of the Mosaico installation.
+## Getting started
+
+1. install and set up Mosaico
+2. copy `mosaico/dist` to your webserver, e.g. to `myserver/mosaico/dist`
+3. copy `mosaico/templates` to youer webserver, e.g. to `myserver/mosaico/templates`
+4. copy `index.html`, `editor.html`, `dl`, `img`, `upload` from this project on top of the Mosaico installation e.g. `myserver/mosaico/*`
+5. run `php composer.phar install` if you want to use InlineStyle on your server. (See https://getcomposer.org/doc/00-intro.md how to get and use composer.)
+    You can do this offline and copy `vendor`to e.g. `myserver/mosaico`; The results of this installation are not checked in to this project.
+6. adapt `config.php` according to your needs and copy it to e.g. `myserver/mosaico`
+7. goto `{url of your server}/mosaico`
+
 
 ## Dependencies
 
 You do need to have Imagemagick support enabled in your PHP configuration.
 
 This project also requires Premailer (http://premailer.dialect.ca/).  Premailer is used to inline the CSS styles.  If that service is ever taken down, we will have to find an alternate solution.  Or, if you have an alternate solution that does not require dependencies on a web service, feel free to contribute!
+
+Alternatively you can use InlineStyle (https://github.com/christiaan/InlineStyle) which runs ony your own server. You need to install it via composer. This is experimental, we will have to investigate if it works well with mosaico.
 
 ## New folders and files
 ```
@@ -45,3 +57,5 @@ This example file has been slightly modified.
 1) The leading slashes in the three paths to the back end (/dl, /img, and /upload) has been removed so that Mosaico can be used in subfolders and not have to be at the root.
 
 2) Trailing slashes have been added to /dl and /upload to avoid 301 redirects which Mosaico does not handle well.  The /img backend path here does not need a trailing slash added because the Mosaico code already adds one when this is used.
+
+# Getting started

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "inlinestyle/inlinestyle": "^1.2"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,119 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "4e173b2a9dad411979481973095b6f7a",
+    "content-hash": "ec03203bcd361b983c62933f0659d8f5",
+    "packages": [
+        {
+            "name": "inlinestyle/inlinestyle",
+            "version": "1.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/christiaan/InlineStyle.git",
+                "reference": "4077e9037112be3a5545094aa3921183553c5f61"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/christiaan/InlineStyle/zipball/4077e9037112be3a5545094aa3921183553c5f61",
+                "reference": "4077e9037112be3a5545094aa3921183553c5f61",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/css-selector": "~2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "InlineStyle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christiaan Baartse"
+                },
+                {
+                    "name": "Michael Tibben"
+                }
+            ],
+            "description": "Apply CSS stylesheets directly as inline styles to a HTML document",
+            "keywords": [
+                "css",
+                "email",
+                "inline"
+            ],
+            "time": "2014-05-21 18:16:54"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v2.7.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "abb47717fb88aebd9437da2fc8bb01a50a36679f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/abb47717fb88aebd9437da2fc8bb01a50a36679f",
+                "reference": "abb47717fb88aebd9437da2fc8bb01a50a36679f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony CssSelector Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-10-30 20:10:21"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/config.php
+++ b/config.php
@@ -5,3 +5,5 @@ $static_dir = "uploads/static/";
 $thumbnails_dir = "uploads/thumbnails/";
 $thumbnail_width = 90;
 $thumbnail_height = 90;
+$style_inliner = 'inlinestyle'; // 'premailer' | 'inlinestyle'
+

--- a/dl/index.php
+++ b/dl/index.php
@@ -2,16 +2,36 @@
 
 chdir( ".." );
 
-require( "config.php" );
-require( "dl/premailer.php" );
 
-/* run this puppy through premailer */
+
+require( "config.php" );
 
 $base_url = ( isset( $_SERVER[ "HTTPS" ] ) ? "https" : "http" ) . "://" . $_SERVER[ "SERVER_NAME" ] . dirname( dirname( $_SERVER[ "PHP_SELF" ] ) ) . "/";
 
-$premailer = Premailer::html( $_POST[ "html" ], true, "hpricot", $base_url );
+use \InlineStyle\InlineStyle;
 
-$html = $premailer[ "html" ];
+switch($style_inliner){
+    /* run this puppy through premailer */
+
+    case 'premailer':
+		require( "dl/premailer.php" );
+		$premailer = Premailer::html( $_POST[ "html" ], false, "hpricot", $base_url );
+		$html = $premailer[ "html" ];
+		break;
+
+	case 'inlinestyler':
+		require 'vendor/autoload.php';
+        $htmldoc = new InlineStyle($_POST["html"]);
+        $htmldoc->applyStylesheet($htmldoc->extractStylesheets());
+        $html = $htmldoc->getHTML();
+        break;
+
+    default:
+       $html = $_POST["html"];
+}
+
+
+
 
 /* create static versions of resized images */
 
@@ -25,20 +45,20 @@ for ( $i = 0; $i < $num_full_pattern_matches; $i++ )
 		{
 			$file_name = urldecode( $src_matches[ 1 ] );
 			$file_name = substr( $file_name, strlen( $uploads_dir ) );
-			
+
 			$method = urldecode( $src_matches[ 2 ] );
-			
+
 			$params = urldecode( $src_matches[ 3 ] );
 			$params = explode( ",", $params );
 			$width = (int) $params[ 0 ];
 			$height = (int) $params[ 1 ];
-			
-			$static_file_name = $static_dir . $method . "_" . $width . "x" . $height . "_" . $file_name;
-			
-			$html = str_ireplace( $matches[ 1 ][ $i ], $base_url . urlencode( $static_file_name ), $html );
-			
+
+			$static_file_name = $static_dir . $method . "_" . $width . "x" . $height . "_" . urlencode( $file_name );
+
+			$html = str_ireplace( $matches[ 1 ][ $i ], $base_url . $static_file_name, $html );
+
 			require( "img/resize.php" );
-			
+
 			$image->writeImage( $static_file_name );
 		}
 	}
@@ -53,30 +73,30 @@ switch ( $_POST[ "action" ] )
 		header( "Content-Type: application/force-download" );
 		header( "Content-Disposition: attachment; filename=\"" . $_POST[ "filename" ] . "\"" );
 		header( "Content-Length: " . strlen( $html ) );
-		
+
 		echo $html;
-		
+
 		break;
 	}
-	
+
 	case "email":
 	{
 		$to = $_POST[ "rcpt" ];
 		$subject = $_POST[ "subject" ];
-		
+
 		$headers = array();
-		
+
 		$headers[] = "MIME-Version: 1.0";
 		$headers[] = "Content-type: text/html; charset=iso-8859-1";
 		$headers[] = "To: $to";
 		$headers[] = "Subject: $subject";
-		
+
 		$headers = implode( "\r\n", $headers );
 
 		if ( mail( $to, $subject, $html, $headers ) === FALSE )
 		{
 			header( $_SERVER[ "SERVER_PROTOCOL" ] . " 500 Internal Server Error" );
-			
+
 			echo "ERR";
 		}
 		else

--- a/editor.html
+++ b/editor.html
@@ -3,6 +3,7 @@
   <head>
 	  <title>HTML Email Editor</title>
     <meta name="viewport" content="width=1024, initial-scale=1">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <link rel="canonical" href="http://mosaico.io" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
Hi,

as I had trouble to get premailer working safely, I have integrated https://github.com/christiaan/InlineStyle. It seems to work properly with mosaico, but this needs to be verified.

It also solves the issues in https://github.com/ainterpreting/mosaico-php-backend/issues/6.

On the first hand I made it configurable, which inliner to be used.

I also updated Readme.md to make it a bit more clear for beginners (as I am ).

I furtheron ignore some generated files and folders.
